### PR TITLE
Modify log message and add Proxy constructor function.

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -18,12 +18,31 @@ type ProxyHandler interface {
 
 // Proxy is the main struct
 type Proxy struct {
-	ClientAddr   string
 	ServerAddr   string
 	Done         chan struct{}
 	Proxyhandler ProxyHandler
 	Timeout      time.Duration
 	Log          Logger
+}
+
+func NewSimpleProxy(addr string, handler ProxyHandler) *Proxy {
+	return &Proxy{
+		ServerAddr:   addr,
+		Proxyhandler: handler,
+		Timeout:      time.Second * 60,
+		Log:          nil,
+		Done:         nil,
+	}
+}
+
+func NewProxy(addr string, handler ProxyHandler, done chan struct{}, timeout time.Duration, log Logger) *Proxy {
+	return &Proxy{
+		ServerAddr:   addr,
+		Done:         done,
+		Proxyhandler: handler,
+		Timeout:      timeout,
+		Log:          log,
+	}
 }
 
 // Start is the main function to start a proxy

--- a/types.go
+++ b/types.go
@@ -142,3 +142,7 @@ type Error struct {
 
 // Error returns the underying error string
 func (e *Error) Error() string { return e.Err.Error() }
+
+func NewError(reason RequestReplyReason, err error) *Error {
+	return &Error{Reason: reason, Err: err}
+}


### PR DESCRIPTION
The below error message is annoying, since these situations are quite common in proxy. Maybe they shouldn't be treated as Error.

```
ERRO[0032] socks error: error on copy from Remote to Client: readfrom tcp 127.0.0.1:10801->127.0.0.1:42194: write tcp 127.0.0.1:10801->127.0.0.1:42194: write: broken pipe 
ERRO[0032] write tcp 127.0.0.1:10801->127.0.0.1:42194: write: broken pipe 
ERRO[0149] socks error: EOF    
```

I changed these message  from Error to Debug.

And modified some log message to show more useful message like below.

```
INFO[0063] Connection established 127.0.0.1:44260 - push.services.mozilla.com:443 
INFO[0064] Connection established 127.0.0.1:44262 - firefox.settings.services.mozilla.com:443 
WARN[0132] Connecting to trace.qq.com:443 failed: EOF   
WARN[0132] Connecting to trace.qq.com:443 failed: EOF   

```