### PR TITLE
feat: allow amending context in Init

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ The SOCKS protocol is defined in [rfc1928](https://tools.ietf.org/html/rfc1928)
 
 ```golang
 type ProxyHandler interface {
-	Init(context.Context, Request) (io.ReadWriteCloser, *Error)
+	Init(context.Context, Request) (context.Context, io.ReadWriteCloser, *Error)
 	ReadFromClient(context.Context, io.ReadCloser, io.WriteCloser) error
 	ReadFromRemote(context.Context, io.ReadCloser, io.WriteCloser) error
 	Close(context.Context) error
@@ -24,7 +24,7 @@ type ProxyHandler interface {
 
 ### Init
 
-Init is called before the copy operations and it should return a connection to the target that is ready to receive data.
+Init is called before the copy operations and it should return a connection to the target that is ready to receive data. It may also amend the context used throughout the lifecycle of the request.
 
 ### ReadFromClient
 

--- a/defaulthandler.go
+++ b/defaulthandler.go
@@ -17,16 +17,16 @@ type DefaultHandler struct {
 }
 
 // Init is the default socks5 implementation
-func (s DefaultHandler) Init(ctx context.Context, request Request) (io.ReadWriteCloser, *Error) {
+func (s DefaultHandler) Init(ctx context.Context, request Request) (context.Context, io.ReadWriteCloser, *Error) {
 	target := request.GetDestinationString()
 	if s.Log != nil {
 		s.Log.Infof("Connecting to target %s", target)
 	}
 	remote, err := net.DialTimeout("tcp", target, s.Timeout)
 	if err != nil {
-		return nil, NewError(RequestReplyHostUnreachable, fmt.Errorf("error on connecting to server: %w", err))
+		return ctx, nil, NewError(RequestReplyHostUnreachable, fmt.Errorf("error on connecting to server: %w", err))
 	}
-	return remote, nil
+	return ctx, remote, nil
 }
 
 const bufferSize = 10240

--- a/logger.go
+++ b/logger.go
@@ -3,12 +3,12 @@ package socks
 type Logger interface {
 	Debug(args ...interface{})
 	Debugf(format string, args ...interface{})
-	Infof(format string, args ...interface{})
 	Info(args ...interface{})
-	Error(args ...interface{})
-	Errorf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
 	Warn(args ...interface{})
 	Warnf(format string, args ...interface{})
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
 }
 
 type NilLogger struct {
@@ -16,9 +16,9 @@ type NilLogger struct {
 
 func (l *NilLogger) Debug(args ...interface{})                 {}
 func (l *NilLogger) Debugf(format string, args ...interface{}) {}
-func (l *NilLogger) Infof(format string, args ...interface{})  {}
 func (l *NilLogger) Info(args ...interface{})                  {}
-func (l *NilLogger) Error(args ...interface{})                 {}
-func (l *NilLogger) Errorf(format string, args ...interface{}) {}
+func (l *NilLogger) Infof(format string, args ...interface{})  {}
 func (l *NilLogger) Warn(args ...interface{})                  {}
 func (l *NilLogger) Warnf(format string, args ...interface{})  {}
+func (l *NilLogger) Error(args ...interface{})                 {}
+func (l *NilLogger) Errorf(format string, args ...interface{}) {}

--- a/proxy.go
+++ b/proxy.go
@@ -9,7 +9,7 @@ import (
 
 // ProxyHandler is the interface for handling the proxy requests
 type ProxyHandler interface {
-	Init(context.Context, Request) (io.ReadWriteCloser, *Error)
+	Init(context.Context, Request) (context.Context, io.ReadWriteCloser, *Error)
 	ReadFromClient(context.Context, io.ReadCloser, io.WriteCloser) error
 	ReadFromRemote(context.Context, io.ReadCloser, io.WriteCloser) error
 	Close(context.Context) error


### PR DESCRIPTION
#### Enhancing Contextual Awareness in ProxyHandler

While this library performs admirably, a critical aspect is lacking in my view: context between handler calls.

In my application, it's imperative to discern which connection is presently managed in each call. Although one could resort to `context.AfterFunc(ctx, fun)` within `ProxyHandler.Init`, it proves impractical and undermines the purpose of the `ProxyHandler.Close` function. This PR introduces the capability to enrich the context with pertinent values, enabling the tracking of requests throughout their lifecycle and facilitating appropriate actions at each stage.

I trust you find these adjustments beneficial. Keep up the exceptional work! 😊